### PR TITLE
CheckAppointmentCommand: add new command for appointment checks

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CheckAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CheckAppointmentCommand.java
@@ -1,0 +1,90 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+
+import java.time.LocalDate;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.Doctor;
+import seedu.address.model.person.Id;
+import seedu.address.model.person.Person;
+
+/**
+ * Checks for appointments of an existing patient in the system.
+ */
+public class CheckAppointmentCommand extends Command {
+
+    public static final String COMMAND_WORD = "checkAppointment";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Checks the appointments of the doctor identified "
+            + "by the doctor ID. "
+            + "Parameters: DOCTOR_ID (must be a valid ID) "
+            + "LOCAL_DATETIME \n"
+            + "Example: " + COMMAND_WORD + " " + PREFIX_ID + " 01" + PREFIX_DAY_DATE + " 2023-09-25";
+
+    public static final String MESSAGE_CHECK_APPOINTMENT_SUCCESS = "Checked appointment for Doctor: %1$s on %2$s";
+    public static final String MESSAGE_NO_APPOINTMENT_FOUND = "No appointment found for Doctor: %1$s on %2$s";
+
+    public static final String MESSAGE_NO_DATE_TIME = "No date time is given for Doctor appointment: %1$s on %2$s";
+
+    private final Id doctorId;
+    private final LocalDate date;
+
+    /**
+     * @param doctorId of the patient to check the appointment of
+     * @param date the specific date and time of the appointment to check (optional)
+     */
+    public CheckAppointmentCommand(Id doctorId, LocalDate date) {
+        requireNonNull(doctorId); // Only patientId is mandatory
+        this.doctorId = doctorId;
+        this.date = date;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        ObservableList<Person> allPersons = model.getFilteredPersonList();
+        Doctor doctorToCheckAppointment = model.getFilteredDoctorById(allPersons, doctorId);
+        if (doctorToCheckAppointment == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+
+        LocalDate appointmentDateTime;
+        String appointmentDetails;
+        if (date != null) {
+            appointmentDateTime = date;
+            appointmentDetails = doctorToCheckAppointment.getOneDayDoctorAppointment(appointmentDateTime, doctorId);
+        } else {
+            throw new CommandException(String.format(MESSAGE_NO_DATE_TIME, doctorToCheckAppointment.getName()));
+        }
+
+        if (appointmentDetails == null || appointmentDetails.isEmpty()) {
+            throw new CommandException(String.format(MESSAGE_NO_APPOINTMENT_FOUND, doctorToCheckAppointment.getName()));
+        }
+
+        return new CommandResult(appointmentDetails);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof CheckAppointmentCommand)) {
+            return false;
+        }
+
+        // state check
+        CheckAppointmentCommand e = (CheckAppointmentCommand) other;
+        return doctorId.equals(e.doctorId)
+                && (date == null ? e.date == null : date.equals(e.date));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewHistoryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewHistoryCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 
 import java.time.LocalDateTime;
 
@@ -23,7 +25,7 @@ public class ViewHistoryCommand extends Command {
             + "by the patient ID. "
             + "Parameters: PATIENT_ID (must be a valid ID) "
             + "LOCAL_DATETIME \n"
-            + "Example: " + COMMAND_WORD + " P1234567A 2023-09-25T10:15";
+            + "Example: " + COMMAND_WORD + " " + PREFIX_ID + "01" + PREFIX_DATE + "2023-09-25 10:15";
 
     public static final String MESSAGE_VIEW_HISTORY_SUCCESS = "Viewed history for Patient: %1$s on %2$s";
     public static final String MESSAGE_NO_HISTORY_FOUND = "No history found for Patient: %1$s on %2$s";

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddAppointmentCommand;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.AddNotesCommand;
+import seedu.address.logic.commands.CheckAppointmentCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CreatePatientCommand;
@@ -100,6 +101,9 @@ public class AddressBookParser {
 
         case AddNotesCommand.COMMAND_WORD:
             return new AddNotesCommandParser().parse(arguments);
+
+        case CheckAppointmentCommand.COMMAND_WORD:
+            return new CheckAppointmentCommandParser().parse(arguments);
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/logic/parser/CheckAppointmentCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/CheckAppointmentCommandParser.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.parser;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DAY_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
+
+import java.time.LocalDate;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import seedu.address.commons.exceptions.InvalidIdException;
+import seedu.address.logic.commands.CheckAppointmentCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Id;
+
+/**
+ * Parses input arguments and creates a new CheckAppointmentCommand object.
+ */
+public class CheckAppointmentCommandParser implements Parser<CheckAppointmentCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the CheckAppointmentCommand
+     * and returns a CheckAppointmentCommand object for execution.
+     *
+     * @param args the input arguments string.
+     * @return a CheckAppointmentCommand object.
+     * @throws ParseException if the user input does not conform to the expected format.
+     */
+    @Override
+    public CheckAppointmentCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+
+        // Tokenize the arguments and look for the /d (date) and /id (doctor ID) prefixes
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_DAY_DATE);
+
+        // Check if both /d and /id prefixes are present, and there is no unexpected preamble
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_ID, PREFIX_DAY_DATE)
+                || !argumentMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
+                    CheckAppointmentCommand.MESSAGE_USAGE));
+        }
+
+        // Parse the doctor ID
+        Id doctorId;
+        try {
+            doctorId = ParserUtil.parseDoctorId(argumentMultimap.getAllValues(PREFIX_ID).get(0));
+        } catch (InvalidIdException e) {
+            throw new ParseException(MESSAGE_INVALID_ID, e);
+        }
+
+        LocalDate date = null;
+        Optional<String> dateString = argumentMultimap.getValue(PREFIX_DAY_DATE);
+        if (dateString.isPresent()) {
+            try {
+                date = ParserUtil.parseDayDate(dateString.get().trim());
+            } catch (ParseException e) {
+                throw new ParseException("Invalid date format. Please use yyyy-MM-dd.");
+            }
+        }
+
+        // Return the constructed CheckAppointmentCommand with doctorId and the parsed or null date
+        return new CheckAppointmentCommand(doctorId, date);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -13,6 +13,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_TAG = new Prefix("t/");
     public static final Prefix PREFIX_REMARK = new Prefix("r/");
     public static final Prefix PREFIX_DATE = new Prefix("x/");
+    public static final Prefix PREFIX_DAY_DATE = new Prefix("y/");
 
     public static final Prefix PREFIX_ID = new Prefix("z/");
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
@@ -110,6 +111,31 @@ public class ParserUtil {
         }
         return time;
     }
+
+    /**
+     * Parses a {@code String date} into a {@code LocalDate}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code date} is invalid or not in the expected format.
+     */
+    public static LocalDate parseDayDate(String date) throws ParseException {
+        requireNonNull(date);
+        String trimmedDate = date.trim();
+        LocalDate parsedDate;
+        LocalDate currentDate = LocalDate.now();
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        try {
+            parsedDate = LocalDate.parse(trimmedDate, formatter);
+        } catch (DateTimeParseException e) {
+            throw new ParseException("Invalid date format, please use yyyy-MM-dd.");
+        }
+
+        if (currentDate.isAfter(parsedDate)) {
+            throw new ParseException("Invalid date entered. The date can't be in the past!");
+        }
+        return parsedDate;
+    }
+
 
     /**
      * Parses a {@code String phone} into a {@code Phone}.

--- a/src/main/java/seedu/address/model/person/History.java
+++ b/src/main/java/seedu/address/model/person/History.java
@@ -182,7 +182,7 @@ public class History {
         for (LocalDateTime date : appointments) {
             Appointment appointment = appointmentDatabase.get(date);
             if (appointment.getPatientId().equals(patientId)) {
-                result.append(formatAppointment(date, appointment)).append("\n");
+                result.append(appointment).append("\n");
             }
         }
         return result.toString();
@@ -201,7 +201,7 @@ public class History {
             if (checkId.equals(doctorId)) {
                 LocalDateTime date = entry.getKey();
                 Appointment appointment = entry.getValue();
-                sb.append(formatAppointment(date, appointment)).append("\n");
+                sb.append(appointment).append("\n");
             }
         }
         return sb.toString();
@@ -224,7 +224,8 @@ public class History {
             if (appointmentDateTime.toLocalDate().equals(date)
                     && appointment.getPatientId().equals(patientId)
                     && appointment.getDoctorId().equals(doctorId)) {
-                sb.append(formatAppointment(appointmentDateTime, appointment));
+                sb.append(appointment)
+                        .append(System.lineSeparator());
             }
         }
         if (sb.isEmpty()) {
@@ -233,6 +234,30 @@ public class History {
         return sb.toString();
     }
 
+    /**
+     * Retrieves all appointments for a specific day for a doctor.
+     *
+     * @param date The date to check.
+     * @param doctorId The ID of the doctor.
+     * @return A list of appointments on the specified day.
+     * @throws AppNotFoundException if no appointments are found for the specified date.
+     */
+    public String getDoctorAppointmentsForDay(LocalDate date, Id doctorId)
+            throws AppNotFoundException {
+        StringBuilder sb = new StringBuilder();
+        for (LocalDateTime appointmentDateTime : appointments) {
+            Appointment appointment = appointmentDatabase.get(appointmentDateTime);
+            if (appointmentDateTime.toLocalDate().equals(date)
+                    && appointment.getDoctorId().equals(doctorId)) {
+                sb.append(appointment)
+                        .append(System.lineSeparator());
+            }
+        }
+        if (sb.isEmpty()) {
+            throw new AppNotFoundException("No appointments found for the specified date.");
+        }
+        return sb.toString();
+    }
     /**
      * Retrieves all appointments for a specific patient within the past 'n' days.
      *
@@ -255,7 +280,8 @@ public class History {
 
             if (!appointmentDate.isBefore(startDate) && !appointmentDate.isAfter(currentDate)
                     && appointment.getPatientId().equals(patientId)) {
-                sb.append(formatAppointment(appointmentDateTime, appointment));
+                sb.append(appointment)
+                        .append(System.lineSeparator());
             }
         }
 
@@ -297,7 +323,8 @@ public class History {
 
             if (!appointmentDate.isBefore(startDate) && !appointmentDate.isAfter(mostRecentDate)
                     && appointment.getDoctorId().equals(doctorId)) {
-                sb.append(formatAppointment(entry.getKey(), appointment));
+                sb.append(appointment)
+                        .append(System.lineSeparator());
             }
         }
 

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.HashSet;
@@ -87,6 +88,15 @@ public class Person implements Appointmentable {
             return appointment.toString(); // Assuming the Appointment class has a toString() method for formatting
         } catch (AppNotFoundException e) {
             return "No appointment found for the given date, patient, and doctor.";
+        }
+    }
+
+    public String getOneDayDoctorAppointment(LocalDate date, Id doctorId) {
+        try {
+            String appointments = history.getDoctorAppointmentsForDay(date, doctorId);
+            return appointments; // Assuming the Appointment class has a toString() method for formatting
+        } catch (AppNotFoundException e) {
+            return "No appointment found for the given date and doctor.";
         }
     }
 


### PR DESCRIPTION
The system currently lacks functionality to check doctor appointments for a specific day. There is a need to enable users to check appointments based on doctor ID and a specific date.

This commit adds the CheckAppointmentCommand, which allows users to check a doctor's appointments for a particular day using the doctor's ID and date. The command throws appropriate error messages when no date is provided or no appointments are found for the given day.