### PR TITLE
Add test for CreateDoctorCommand execution success

### DIFF
--- a/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
@@ -1,0 +1,235 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CreateDoctorCommand.MESSAGE_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class CreateDoctorCommandTest {
+
+    @Test
+    public void execute_Doctor_addSuccessful() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();  // Clear the list
+
+        Person validDoctor = new PersonBuilder().buildDoctor();
+
+        CommandResult commandResult = new CreateDoctorCommand(validDoctor).execute(modelStub);
+
+        assertEquals(String.format(MESSAGE_SUCCESS, validDoctor.getId(), Messages.format(validDoctor)),
+                commandResult.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_Multiple_Doctor_addFailure() {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validDoctor = new PersonBuilder().buildDoctor();
+        modelStub.addPerson(validDoctor);  // Add first doctor
+
+        assertThrows(
+                CommandException.class,  // expected exception type
+                CreateDoctorCommand.MESSAGE_DUPLICATE_PERSON,  // expected message
+                () -> new CreateDoctorCommand(validDoctor).execute(modelStub)  // executable
+        );
+    }
+
+
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return null;
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonById(int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredPersonById(ObservableList<Person> allPersons, int id) {
+            return null; // TODO?
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        }
+    }
+    /**
+     * A Model stub that contains a single person.
+     */
+    private class ModelStubWithAppointment extends CreateDoctorCommandTest.ModelStub {
+        private final Person patient;
+        private final Person doctor;
+
+        ModelStubWithAppointment(Person patient, Person doctor) {
+            requireNonNull(patient);
+            requireNonNull(doctor);
+            this.patient = patient;
+            this.doctor = doctor;
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return person.isSamePerson(patient) || person.isSamePerson(doctor);
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(patient, doctor);
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return patient.getId() == (id) ? patient : null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return doctor.getId() == (id) ? doctor : null;
+        }
+    }
+
+    /**
+     * A Model stub that always accept the appointment being added.
+     */
+    public class ModelStubAcceptingAppointmentAdded extends CreateDoctorCommandTest.ModelStub {
+
+        private final ArrayList<Person> personList = new ArrayList<>();
+
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return personList.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            requireNonNull(person);
+            personList.add(person);
+        }
+
+        public void clearList() {
+            personList.clear();
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            // Search for a patient with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            // Search for a doctor with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(personList);
+        }
+        public void addPersonToList(Person person) {
+            personList.add(person);
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
@@ -24,9 +24,9 @@ import seedu.address.testutil.PersonBuilder;
 public class CreateDoctorCommandTest {
 
     @Test
-    public void execute_Doctor_addSuccessful() throws Exception {
+    public void executeDoctorAddSuccessful() throws Exception {
         ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
-        modelStub.clearList();  // Clear the list
+        modelStub.clearList(); // Clear the list
 
         Person validDoctor = new PersonBuilder().buildDoctor();
 
@@ -37,18 +37,17 @@ public class CreateDoctorCommandTest {
     }
 
     @Test
-    public void execute_Multiple_Doctor_addFailure() {
+    public void executeMultipleDoctorAddFailure() {
         ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
         modelStub.clearList();
 
         Person validDoctor = new PersonBuilder().buildDoctor();
-        modelStub.addPerson(validDoctor);  // Add first doctor
+        modelStub.addPerson(validDoctor); // Add first doctor
 
         assertThrows(
-                CommandException.class,  // expected exception type
-                CreateDoctorCommand.MESSAGE_DUPLICATE_PERSON,  // expected message
-                () -> new CreateDoctorCommand(validDoctor).execute(modelStub)  // executable
-        );
+                CommandException.class, // expected exception type
+                CreateDoctorCommand.MESSAGE_DUPLICATE_PERSON, // expected message
+                () -> new CreateDoctorCommand(validDoctor).execute(modelStub)); // executable
     }
 
 

--- a/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
@@ -2,6 +2,7 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.CreateDoctorCommand.MESSAGE_DUPLICATE_PERSON;
 import static seedu.address.logic.commands.CreateDoctorCommand.MESSAGE_SUCCESS;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -44,10 +45,8 @@ public class CreateDoctorCommandTest {
         Person validDoctor = new PersonBuilder().buildDoctor();
         modelStub.addPerson(validDoctor); // Add first doctor
 
-        assertThrows(
-                CommandException.class, // expected exception type
-                CreateDoctorCommand.MESSAGE_DUPLICATE_PERSON, // expected message
-                () -> new CreateDoctorCommand(validDoctor).execute(modelStub)); // executable
+        assertThrows(CommandException.class, MESSAGE_DUPLICATE_PERSON, () ->
+                new CreateDoctorCommand(validDoctor).execute(modelStub));
     }
 
 

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -17,7 +17,7 @@ import seedu.address.model.util.SampleDataUtil;
  */
 public class PersonBuilder {
 
-    public static final String DEFAULT_NAME = "Amy Bee";
+    public static final String DEFAULT_NAME = "Amy Beeee";
     public static final String DEFAULT_PATIENT_ROLE = "patient";
     public static final String DEFAULT_DOCTOR_ROLE = "doctor";
     public static final String DEFAULT_PHONE = "85355255";


### PR DESCRIPTION
CreateDoctorCommand lacks a test to verify the successful addition of a doctor.

Adding a test to ensure that a doctor is successfully added through the CreateDoctorCommand helps to validate that the command works as intended. This test ensures the command produces the expected success message upon adding a doctor.