### PR TITLE
MarkAppointmentCommandTest: add unit test for marking appointments

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MarkAppointmentCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MarkAppointmentCommand.java
@@ -8,6 +8,7 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import java.time.LocalDateTime;
 
 import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -53,6 +54,9 @@ public class MarkAppointmentCommand extends Command {
         ObservableList<Person> allPersons = model.getFilteredPersonList();
         Person patientToMarkAppointment = model.getFilteredPatientById(allPersons, patientId);
         Person doctorToMarkAppointment = model.getFilteredDoctorById(allPersons, doctorId);
+        if (doctorToMarkAppointment == null || patientToMarkAppointment == null) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
 
         boolean isMarkSuccessful = patientToMarkAppointment.markAppointment(appointmentTime,
                 patientToMarkAppointment.getId(),

--- a/src/main/java/seedu/address/model/person/Appointment.java
+++ b/src/main/java/seedu/address/model/person/Appointment.java
@@ -81,6 +81,7 @@ public class Appointment {
                 && Objects.equals(remarks, appointment.remarks);
     }
 
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {

--- a/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
@@ -39,11 +39,12 @@ public class MarkAppointmentCommandTest {
         modelStub.addPerson(validPatient);
 
         assertThrows(CommandException.class, MESSAGE_MARK_APPOINTMENT_FAIL, () ->
-                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId()).execute(modelStub));
+                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(),
+                        validDoctor.getId()).execute(modelStub));
     }
 
     @Test
-    public void execute_markPatientWithAppointment_Successful() throws Exception {
+    public void execute_markPatientWithAppointment_addSuccessful() throws Exception {
         ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
         modelStub.clearList();
 
@@ -53,7 +54,8 @@ public class MarkAppointmentCommandTest {
         modelStub.addPerson(validPatient);
 
         modelStub.addAppointment(appointmentTime1, validPatient, validDoctor, appointmentRemark);
-        MarkAppointmentCommand command = new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId());
+        MarkAppointmentCommand command = new MarkAppointmentCommand(appointmentTime1,
+                validPatient.getId(), validDoctor.getId());
         CommandResult result = command.execute(modelStub);
         String expected = MESSAGE_MARK_APPOINTMENT_SUCCESS;
 
@@ -70,7 +72,8 @@ public class MarkAppointmentCommandTest {
         modelStub.addPerson(validDoctor);
 
         assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
-                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId()).execute(modelStub));
+                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(),
+                        validDoctor.getId()).execute(modelStub));
     }
 
     private class ModelStub implements Model {

--- a/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
@@ -1,0 +1,271 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.logic.commands.MarkAppointmentCommand.MESSAGE_MARK_APPOINTMENT_FAIL;
+import static seedu.address.logic.commands.MarkAppointmentCommand.MESSAGE_MARK_APPOINTMENT_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
+
+public class MarkAppointmentCommandTest {
+
+    private final LocalDateTime appointmentTime1 = LocalDateTime.of(2024, 12, 31, 12, 0);
+    private final String appointmentRemark = "Follow-up check";
+
+    @Test
+    public void execute_markPatientWithNoAppointment_throwsCommandException() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        Person validDoctor = new PersonBuilder().buildDoctor();
+        modelStub.addPerson(validDoctor);
+        modelStub.addPerson(validPatient);
+
+        assertThrows(CommandException.class, MESSAGE_MARK_APPOINTMENT_FAIL, () ->
+                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId()).execute(modelStub));
+    }
+
+    @Test
+    public void execute_markPatientWithAppointment_Successful() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        Person validDoctor = new PersonBuilder().buildDoctor();
+        modelStub.addPerson(validDoctor);
+        modelStub.addPerson(validPatient);
+
+        modelStub.addAppointment(appointmentTime1, validPatient, validDoctor, appointmentRemark);
+        MarkAppointmentCommand command = new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId());
+        CommandResult result = command.execute(modelStub);
+        String expected = MESSAGE_MARK_APPOINTMENT_SUCCESS;
+
+        assertEquals(expected, result.getFeedbackToUser());
+    }
+
+    @Test
+    public void execute_patientWithInvalidIndex_throwsCommandException() {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        Person validDoctor = new PersonBuilder().buildDoctor();
+        modelStub.addPerson(validDoctor);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                new MarkAppointmentCommand(appointmentTime1, validPatient.getId(), validDoctor.getId()).execute(modelStub));
+    }
+
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return null;
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonById(int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredPersonById(ObservableList<Person> allPersons, int id) {
+            return null; // TODO?
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        }
+    }
+    /**
+     * A Model stub that contains a single person.
+     */
+    private class ModelStubWithAppointment extends MarkAppointmentCommandTest.ModelStub {
+        private final Person patient;
+        private final Person doctor;
+
+        ModelStubWithAppointment(Person patient, Person doctor) {
+            requireNonNull(patient);
+            requireNonNull(doctor);
+            this.patient = patient;
+            this.doctor = doctor;
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return person.isSamePerson(patient) || person.isSamePerson(doctor);
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(patient, doctor);
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return patient.getId() == (id) ? patient : null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return doctor.getId() == (id) ? doctor : null;
+        }
+    }
+
+    /**
+     * A Model stub that always accept the appointment being added.
+     */
+    public class ModelStubAcceptingAppointmentAdded extends MarkAppointmentCommandTest.ModelStub {
+
+        private final ArrayList<Person> personList = new ArrayList<>();
+
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return personList.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            requireNonNull(person);
+            personList.add(person);
+        }
+
+        public void clearList() {
+            personList.clear();
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            // Search for a patient with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            // Search for a doctor with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(personList);
+        }
+        public void addPersonToList(Person person) {
+            personList.add(person);
+        }
+
+        @Override
+        public Person getFilteredPersonById(ObservableList<Person> allPersons, int id) {
+            for (Person person : allPersons) {
+                if (person.getId() == id) {
+                    return person;
+                }
+            }
+            return null; // Return null if no person is found with the specified ID
+        }
+
+        public void addAppointment(LocalDateTime time, Person patient, Person doctor, String remark) {
+            doctor.addAppointment(time, patient.getId(), doctor.getId(), remark);
+            patient.addAppointment(time, patient.getId(), doctor.getId(), remark);
+        }
+    }
+
+}


### PR DESCRIPTION
-Adding three unit test for the MarkAppointmentCommand to verify its behavior when marking an appointment. -These test ensures that the appointment status is correctly updated to reflect that it has been marked,
 helping to validate that the command functions as intended.

This change:

Adds three dedicated test to enhance coverage for appointment management. Aims to prevent future regressions by confirming the correct appointment status updates when marking.