### PR TITLE
RemarkCommandTest: add unit test for remark functionality

### DIFF
--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 
 import javafx.collections.ObservableList;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -3,16 +3,12 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
-
-import java.util.List;
 
 import javafx.collections.ObservableList;
+
 import seedu.address.commons.core.Messages;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Id;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
 

--- a/src/main/java/seedu/address/logic/commands/RemarkCommand.java
+++ b/src/main/java/seedu/address/logic/commands/RemarkCommand.java
@@ -1,15 +1,18 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import java.util.List;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.person.Id;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Remark;
 
@@ -31,36 +34,31 @@ public class RemarkCommand extends Command {
     public static final String MESSAGE_ADD_REMARK_SUCCESS = "Added remark to Person: %1$s";
     public static final String MESSAGE_DELETE_REMARK_SUCCESS = "Removed remark from Person: %1$s";
 
-    private final Index index;
+    private final int patientId;
     private final Remark remark;
 
     /**
-     * @param index of the person in the filtered person list to edit the remark
+     * @param patientId of the person in the filtered person list to edit the remark
      * @param remark of the person to be updated to
      */
-    public RemarkCommand(Index index, Remark remark) {
-        requireAllNonNull(index, remark);
+    public RemarkCommand(int patientId, Remark remark) {
+        requireAllNonNull(patientId, remark);
 
-        this.index = index;
+        this.patientId = patientId;
         this.remark = remark;
     }
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        List<Person> lastShownList = model.getFilteredPersonList();
-
-        if (index.getZeroBased() >= lastShownList.size()) {
+        requireNonNull(model);
+        ObservableList<Person> allPersons = model.getFilteredPersonList();
+        Person patientToAddRemark = model.getFilteredPatientById(allPersons, patientId);
+        if (patientToAddRemark == null) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
 
-        Person personToEdit = lastShownList.get(index.getZeroBased());
-        Person editedPerson = new Person(personToEdit.getName(),
-                personToEdit.getRole(), personToEdit.getPhone(), personToEdit.getEmail(),
-                personToEdit.getAddress(), remark, personToEdit.getTags());
+        patientToAddRemark.editRemark(remark);
 
-        model.setPerson(personToEdit, editedPerson);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-
-        return new CommandResult(generateSuccessMessage(editedPerson));
+        return new CommandResult(generateSuccessMessage(patientToAddRemark));
     }
 
     /**
@@ -86,7 +84,7 @@ public class RemarkCommand extends Command {
 
         // state check
         RemarkCommand e = (RemarkCommand) other;
-        return index.equals(e.index)
+        return patientId == e.patientId
                 && remark.equals(e.remark);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -3,20 +3,15 @@ package seedu.address.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_ID;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 
-import java.time.LocalDateTime;
-import java.util.Optional;
 import java.util.stream.Stream;
-import seedu.address.commons.core.index.Index;
-import seedu.address.commons.exceptions.IllegalValueException;
+
 import seedu.address.commons.exceptions.InvalidIdException;
 import seedu.address.logic.commands.RemarkCommand;
 import seedu.address.logic.commands.ViewHistoryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Id;
 import seedu.address.model.person.Remark;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -2,12 +2,21 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_ID;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.stream.Stream;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.commons.exceptions.InvalidIdException;
 import seedu.address.logic.commands.RemarkCommand;
+import seedu.address.logic.commands.ViewHistoryCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Id;
 import seedu.address.model.person.Remark;
 
 /**
@@ -26,18 +35,37 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
     @Override
     public RemarkCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_REMARK);
 
-        Index index;
-        try {
-            index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (IllegalValueException ive) {
+        // Tokenize the arguments and look for the /d (date) and /id (patient ID) prefixes
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_ID, PREFIX_REMARK);
+
+        // Check if /z prefixes is present, and there is no unexpected preamble
+        if (!arePrefixesPresent(argumentMultimap, PREFIX_ID)
+                || !argumentMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                    RemarkCommand.MESSAGE_USAGE), ive);
+                    ViewHistoryCommand.MESSAGE_USAGE));
         }
 
-        String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
+        // Parse the patient ID
+        int patientId;
+        try {
+            patientId = ParserUtil.parsePersonId(argumentMultimap.getAllValues(PREFIX_ID).get(0));
+        } catch (InvalidIdException e) {
+            throw new ParseException(MESSAGE_INVALID_ID, e);
+        }
 
-        return new RemarkCommand(index, new Remark(remark));
+        // Parse the date from the /d prefix, or set it to null if not provided
+        Remark remark = new Remark(argumentMultimap.getAllValues(PREFIX_ID).get(0));
+
+        // Return the constructed ViewHistoryCommand with patientId and the parsed or null dateTime
+        return new RemarkCommand(patientId, remark);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -28,7 +28,7 @@ public class Person implements Appointmentable {
     private final Email email;
     private final int id;
     private final Address address;
-    private final Remark remark;
+    private Remark remark;
     private final Set<Tag> tags = new HashSet<>();
     private List<Appointment> appointments;
 
@@ -244,6 +244,9 @@ public class Person implements Appointmentable {
 
     }
 
+    public void editRemark(Remark remark) {
+        this.remark = remark;
+    }
 
     @Override
     public boolean editAppointment(LocalDateTime dateTime, int patientId, int doctorId) {

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -16,7 +16,6 @@ import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.commons.core.index.Index;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/RemarkCommandTest.java
@@ -1,0 +1,291 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.commands.RemarkCommand.MESSAGE_ADD_REMARK_SUCCESS;
+import static seedu.address.logic.commands.RemarkCommand.MESSAGE_DELETE_REMARK_SUCCESS;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import java.nio.file.Path;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.GuiSettings;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.Messages;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Remark;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+import seedu.address.testutil.PersonBuilder;
+
+public class RemarkCommandTest {
+
+    private final LocalDateTime appointmentTime1 = LocalDateTime.of(2024, 12, 31, 12, 0);
+    private final LocalDateTime appointmentTime2 = LocalDateTime.of(2024, 12, 31, 13, 0);
+    private final String appointmentRemark = "Follow-up check";
+
+    @Test
+    public void execute_invalidPatientRemark_throwsException() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        Remark remark = new Remark("Headache");
+
+        assertThrows(CommandException.class, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX, () ->
+                new RemarkCommand(validPatient.getId(), remark).execute(modelStub));
+    }
+
+    @Test
+    public void execute_validPatientRemark_addedSuccessful() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        modelStub.addPerson(validPatient);
+        Remark remark = new Remark("Headache");
+        RemarkCommand command = new RemarkCommand(validPatient.getId(), remark);
+        CommandResult result = command.execute(modelStub);
+
+        String expected = String.format(MESSAGE_ADD_REMARK_SUCCESS, validPatient);
+
+        assertEquals(expected, result.getFeedbackToUser());
+    }
+    @Test
+    public void execute_validPatientRemark_addedFailure() throws Exception {
+        ModelStubAcceptingAppointmentAdded modelStub = new ModelStubAcceptingAppointmentAdded();
+        modelStub.clearList();
+
+        Person validPatient = new PersonBuilder().buildPatient();
+        modelStub.addPerson(validPatient);
+        Remark remark = new Remark("");
+        RemarkCommand command = new RemarkCommand(validPatient.getId(), remark);
+        CommandResult result = command.execute(modelStub);
+
+        String expected = String.format(MESSAGE_DELETE_REMARK_SUCCESS, validPatient);
+
+        assertEquals(expected, result.getFeedbackToUser());
+    }
+
+    private class ModelStub implements Model {
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Path getAddressBookFilePath() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBookFilePath(Path addressBookFilePath) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setAddressBook(ReadOnlyAddressBook newData) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ReadOnlyAddressBook getAddressBook() {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return null;
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonById(int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredPersonById(ObservableList<Person> allPersons, int id) {
+            return null; // TODO?
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return null;
+        }
+
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+        }
+    }
+    /**
+     * A Model stub that contains a single person.
+     */
+    private class ModelStubWithAppointment extends RemarkCommandTest.ModelStub {
+        private final Person patient;
+        private final Person doctor;
+
+        ModelStubWithAppointment(Person patient, Person doctor) {
+            requireNonNull(patient);
+            requireNonNull(doctor);
+            this.patient = patient;
+            this.doctor = doctor;
+        }
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return person.isSamePerson(patient) || person.isSamePerson(doctor);
+        }
+
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(patient, doctor);
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            return patient.getId() == (id) ? patient : null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            return doctor.getId() == (id) ? doctor : null;
+        }
+    }
+
+    /**
+     * A Model stub that always accept the appointment being added.
+     */
+    public class ModelStubAcceptingAppointmentAdded extends RemarkCommandTest.ModelStub {
+
+        private final ArrayList<Person> personList = new ArrayList<>();
+
+
+        @Override
+        public boolean hasPerson(Person person) {
+            requireNonNull(person);
+            return personList.stream().anyMatch(person::isSamePerson);
+        }
+
+        @Override
+        public void addPerson(Person person) {
+            requireNonNull(person);
+            personList.add(person);
+        }
+
+        public void clearList() {
+            personList.clear();
+        }
+
+        @Override
+        public Person getFilteredPatientById(ObservableList<Person> allPersons, int id) {
+            // Search for a patient with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+
+        @Override
+        public Person getFilteredDoctorById(ObservableList<Person> allPersons, int id) {
+            // Search for a doctor with the specified ID
+            for (Person person : allPersons) {
+                if (person.getId() == (id) && person instanceof Person) {
+                    return person;
+                }
+            }
+            return null;
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            return javafx.collections.FXCollections.observableArrayList(personList);
+        }
+        public void addPersonToList(Person person) {
+            personList.add(person);
+        }
+
+        @Override
+        public Person getFilteredPersonById(ObservableList<Person> allPersons, int id) {
+            for (Person person : allPersons) {
+                if (person.getId() == id) {
+                    return person;
+                }
+            }
+            return null; // Return null if no person is found with the specified ID
+        }
+
+        public void addAppointment(LocalDateTime time, Person patient, Person doctor, String remark) {
+            doctor.addAppointment(time, patient.getId(), doctor.getId(), remark);
+            patient.addAppointment(time, patient.getId(), doctor.getId(), remark);
+        }
+
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            requireAllNonNull(target, editedPerson);
+
+            int index = personList.indexOf(target);
+            if (index == -1) {
+                throw new PersonNotFoundException();
+            }
+
+            if (!target.isSamePerson(editedPerson) && personList.contains(editedPerson)) {
+                throw new DuplicatePersonException();
+            }
+
+            personList.set(index, editedPerson);
+        }
+    }
+
+}

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -126,4 +126,25 @@ public class PersonBuilder {
     public Person buildDoctor() {
         return new Person(name, DEFAULT_DOCTOR_ROLE, phone, email, address, remark, tags);
     }
+    /**
+     * builds a patient class with name and phone
+     */
+    public Person buildPatient(String newName, String newPhone) {
+        name = new Name(newName);
+        phone = new Phone(newPhone);
+        return new Person(name, role, phone, email, address, remark, tags);
+    }
+
+    /**
+     * builds a doctor class with name and phone
+     */
+    public Person buildDoctor(String newName, String newPhone) {
+        name = new Name(newName);
+        phone = new Phone(newPhone);
+        return new Person(name, DEFAULT_DOCTOR_ROLE, phone, email, address, remark, tags);
+    }
+
+    public Person buildPatient(Remark remark) {
+        return new Person(name, DEFAULT_PATIENT_ROLE, phone, email, address, remark, tags);
+    }
 }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -126,25 +126,5 @@ public class PersonBuilder {
     public Person buildDoctor() {
         return new Person(name, DEFAULT_DOCTOR_ROLE, phone, email, address, remark, tags);
     }
-    /**
-     * builds a patient class with name and phone
-     */
-    public Person buildPatient(String newName, String newPhone) {
-        name = new Name(newName);
-        phone = new Phone(newPhone);
-        return new Person(name, role, phone, email, address, remark, tags);
-    }
 
-    /**
-     * builds a doctor class with name and phone
-     */
-    public Person buildDoctor(String newName, String newPhone) {
-        name = new Name(newName);
-        phone = new Phone(newPhone);
-        return new Person(name, DEFAULT_DOCTOR_ROLE, phone, email, address, remark, tags);
-    }
-
-    public Person buildPatient(Remark remark) {
-        return new Person(name, DEFAULT_PATIENT_ROLE, phone, email, address, remark, tags);
-    }
 }


### PR DESCRIPTION
Add three unit test for the RemarkCommand to verify its behavior when adding or updating remarks for an appointment. This test ensures that remarks are correctly applied to the relevant appointment, validating the command’s functionality and supporting consistent behavior.

This change introduces a focused test to improve coverage for the remark functionality and aims to prevent future regressions by ensuring remarks update as expected.