### PR TITLE
Fix EditPerson , AddRemarks, CreatePatient and CreateDoctor Commands

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -122,7 +122,7 @@ How the parsing works:
 
 The `Model` component,
 
-* stores the address book data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
+* stores the MedDict data i.e., all `Person` objects (which are contained in a `UniquePersonList` object).
 * stores the currently 'selected' `Person` objects (e.g., results of a search query) as a separate _filtered_ list which is exposed to outsiders as an unmodifiable `ObservableList<Person>` that can be 'observed' e.g. the UI can be bound to this list so that the UI automatically updates when the data in the list change.
 * stores a `UserPref` object that represents the user’s preferences. This is exposed to the outside as a `ReadOnlyUserPref` objects.
 * does not depend on any of the other three components (as the `Model` represents data entities of the domain, they should make sense on their own without depending on other components)

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -26,6 +26,9 @@ public class Messages {
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_GET_ID = "The id of the person that you are finding is: %1$d";
+    public static final String MESSAGE_MULTIPLE_PERSONS_WITH_THE_SAME_NAME = "%1$d persons listed "
+            + "that suits your keyword!\n"
+            + "enters more specific name keywords to retrieve the id of the person";
 
 
     /**

--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -15,11 +15,14 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
-    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
+    public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed! "
+            + "Key in [list] to view all patients ";
     public static final String MESSAGE_INVALID_ID = "Invalid Id entered! Check the id that you have entered!";
+    public static final String MESSAGE_EMPTY_REMARK = "The remark you have entered is empty! "
+            + "Please enter a valid input!";
     public static final String MESSAGE_INVALID_NAME = "Invalid name entered! "
             + "Check the name that you want to search id for!\n"
-            + "Key in 'list' to view all patients";
+            + "Key in [list] to view all patients";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
     public static final String MESSAGE_GET_ID = "The id of the person that you are finding is: %1$d";

--- a/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
@@ -30,7 +30,7 @@ public class AddRemarksCommand extends Command {
             + PREFIX_REMARK + "Much better than previous appointment.";
 
     public static final String MESSAGE_ADD_REMARKS_SUCCESS = "Successfully "
-            + "added remarks: %s to patient of ID: %d.";
+            + "added remarks: '%s' to patient of ID: %d.";
     public static final String MESSAGE_ADD_NOTES_FAILURE = "Unable to "
             + "add remarks! Check the id entered!";
     private final int patientId;
@@ -53,12 +53,17 @@ public class AddRemarksCommand extends Command {
 
         requireNonNull(model);
         ObservableList<Person> allPersons = model.getFilteredPersonList();
-        Person patientToAddNotes = model.getFilteredPatientById(allPersons, patientId);
-        if (patientToAddNotes == null) {
+        Person patientToAddRemarks = model.getFilteredPatientById(allPersons, patientId);
+        if (patientToAddRemarks == null) {
             throw new CommandException(MESSAGE_ADD_NOTES_FAILURE);
         }
-        patientToAddNotes.addNotes(additionalNotes);
+        Person editedPatient = new Person(patientToAddRemarks.getName(),
+                patientToAddRemarks.getId(), patientToAddRemarks.getRole(), patientToAddRemarks.getPhone(),
+                patientToAddRemarks.getEmail(), patientToAddRemarks.getAddress(),
+                patientToAddRemarks.addRemarks(additionalNotes),
+                patientToAddRemarks.getAppointments(), patientToAddRemarks.getTags());
 
+        model.setPerson(patientToAddRemarks, editedPatient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
         return new CommandResult(String.format(MESSAGE_ADD_REMARKS_SUCCESS, additionalNotes, patientId

--- a/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
@@ -10,7 +10,7 @@ import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
-
+import seedu.address.model.person.Remark;
 
 
 /**
@@ -34,18 +34,17 @@ public class AddRemarksCommand extends Command {
     public static final String MESSAGE_ADD_NOTES_FAILURE = "Unable to "
             + "add remarks! Check the id entered!";
     private final int patientId;
-    private final String additionalNotes;
+    private final Remark additionalRemarks;
 
     /**
      * Adds notes to a Patient's remarks
      * @param patientId patient id
-     * @param additionalNotes notes to be added
+     * @param remarks additional remarks to be added
      */
-    public AddRemarksCommand(int patientId, String additionalNotes) {
-        requireAllNonNull(patientId, additionalNotes);
-
+    public AddRemarksCommand(int patientId, Remark remarks) {
+        requireAllNonNull(remarks);
         this.patientId = patientId;
-        this.additionalNotes = additionalNotes;
+        this.additionalRemarks = remarks;
     }
 
     @Override
@@ -60,13 +59,14 @@ public class AddRemarksCommand extends Command {
         Person editedPatient = new Person(patientToAddRemarks.getName(),
                 patientToAddRemarks.getId(), patientToAddRemarks.getRole(), patientToAddRemarks.getPhone(),
                 patientToAddRemarks.getEmail(), patientToAddRemarks.getAddress(),
-                patientToAddRemarks.addRemarks(additionalNotes),
+                patientToAddRemarks.addRemarks(additionalRemarks.getValue()),
                 patientToAddRemarks.getAppointments(), patientToAddRemarks.getTags());
 
         model.setPerson(patientToAddRemarks, editedPatient);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
 
-        return new CommandResult(String.format(MESSAGE_ADD_REMARKS_SUCCESS, additionalNotes, patientId
+        return new CommandResult(String.format(MESSAGE_ADD_REMARKS_SUCCESS,
+                additionalRemarks, patientId
         ));
     }
     @Override
@@ -85,6 +85,6 @@ public class AddRemarksCommand extends Command {
 
         // Compare patientId and additionalNotes
         return patientId == otherCommand.patientId
-                && additionalNotes.equals(otherCommand.additionalNotes);
+                && additionalRemarks.equals(otherCommand.additionalRemarks);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddRemarksCommand.java
@@ -20,7 +20,7 @@ public class AddRemarksCommand extends Command {
 
     public static final String COMMAND_WORD = "addR";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds remarks to the patient."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds remarks to the patient. "
             + "Existing remarks will be concatenated by the input.\n"
             + COMMAND_WORD + " "
             + PREFIX_ID + "[PATIENT_ID] "
@@ -31,8 +31,10 @@ public class AddRemarksCommand extends Command {
 
     public static final String MESSAGE_ADD_REMARKS_SUCCESS = "Successfully "
             + "added remarks: '%s' to patient of ID: %d.";
-    public static final String MESSAGE_ADD_NOTES_FAILURE = "Unable to "
+    public static final String MESSAGE_ADD_REMARKS_FAILURE = "Unable to "
             + "add remarks! Check the id entered!";
+    public static final String MESSAGE_WRONG_ROLE = "Unable to add remarks for a doctor.\n"
+            + " Please check the id of the person you are adding remarks to!";
     private final int patientId;
     private final Remark additionalRemarks;
 
@@ -54,7 +56,10 @@ public class AddRemarksCommand extends Command {
         ObservableList<Person> allPersons = model.getFilteredPersonList();
         Person patientToAddRemarks = model.getFilteredPatientById(allPersons, patientId);
         if (patientToAddRemarks == null) {
-            throw new CommandException(MESSAGE_ADD_NOTES_FAILURE);
+            throw new CommandException(MESSAGE_ADD_REMARKS_FAILURE);
+        }
+        if (patientToAddRemarks.getRole().equals("DOCTOR")) {
+            throw new CommandException(MESSAGE_WRONG_ROLE);
         }
         Person editedPatient = new Person(patientToAddRemarks.getName(),
                 patientToAddRemarks.getId(), patientToAddRemarks.getRole(), patientToAddRemarks.getPhone(),

--- a/src/main/java/seedu/address/logic/commands/ClearCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ClearCommand.java
@@ -11,7 +11,7 @@ import seedu.address.model.Model;
 public class ClearCommand extends Command {
 
     public static final String COMMAND_WORD = "clear";
-    public static final String MESSAGE_SUCCESS = "Address book has been cleared!";
+    public static final String MESSAGE_SUCCESS = "MedDict has been cleared!";
 
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CreateDoctorCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateDoctorCommand.java
@@ -33,6 +33,8 @@ public class CreateDoctorCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Successfully created a new doctor Doctor#%d : %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This doctor already exists";
+    public static final String MESSAGE_OVERLAPPING_PATIENT = "This person already exists as a patient\n"
+            + "Please check the details you have entered!";
 
     private final Person toAdd;
 
@@ -49,7 +51,12 @@ public class CreateDoctorCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            if (model.getPersonRole(toAdd).equals("DOCTOR")) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            }
+            if (model.getPersonRole(toAdd).equals("PATIENT")) {
+                throw new CommandException(MESSAGE_OVERLAPPING_PATIENT);
+            }
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/CreatePatientCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreatePatientCommand.java
@@ -31,6 +31,8 @@ public class CreatePatientCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Successfully created a new patient Patient#%d : %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This patient already exists";
+    public static final String MESSAGE_OVERLAPPING_DOCTOR = "This person already exists as a doctor!\n"
+            + "Please check the details you have entered!";
 
     private final Person toAdd;
 
@@ -47,7 +49,12 @@ public class CreatePatientCommand extends Command {
         requireNonNull(model);
 
         if (model.hasPerson(toAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            if (model.getPersonRole(toAdd).equals("PATIENT")) {
+                throw new CommandException(MESSAGE_DUPLICATE_PERSON);
+            }
+            if (model.getPersonRole(toAdd).equals("DOCTOR")) {
+                throw new CommandException(MESSAGE_OVERLAPPING_DOCTOR);
+            }
         }
 
         model.addPerson(toAdd);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -208,7 +208,9 @@ public class EditCommand extends Command {
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
         }
-        public void setRemark(Remark remarks) { this.remarks = remarks; }
+        public void setRemark(Remark remarks) {
+            this.remarks = remarks;
+        }
 
         public Optional<Remark> getRemarks() {
             return Optional.ofNullable(remarks);

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_REMARK;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
@@ -49,6 +50,7 @@ public class EditCommand extends Command {
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
             + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_REMARK + "REMARKS]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_ID + "1 "
             + PREFIX_PHONE + "91234567 "
@@ -145,6 +147,7 @@ public class EditCommand extends Command {
         private Phone phone;
         private Email email;
         private Address address;
+        private Remark remarks;
         private Set<Tag> tags;
 
         public EditPersonDescriptor() {}
@@ -158,6 +161,7 @@ public class EditCommand extends Command {
             setPhone(toCopy.phone);
             setEmail(toCopy.email);
             setAddress(toCopy.address);
+            setRemark(toCopy.remarks);
             setTags(toCopy.tags);
         }
 
@@ -204,6 +208,11 @@ public class EditCommand extends Command {
         public Optional<Address> getAddress() {
             return Optional.ofNullable(address);
         }
+        public void setRemark(Remark remarks) { this.remarks = remarks; }
+
+        public Optional<Remark> getRemarks() {
+            return Optional.ofNullable(remarks);
+        }
 
         /**
          * Sets {@code tags} to this object's {@code tags}.
@@ -238,6 +247,7 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
+                    && Objects.equals(remarks, otherEditPersonDescriptor.remarks)
                     && Objects.equals(tags, otherEditPersonDescriptor.tags);
         }
 
@@ -248,6 +258,7 @@ public class EditCommand extends Command {
                     .add("phone", phone)
                     .add("email", email)
                     .add("address", address)
+                    .add("remarks", remarks)
                     .add("tags", tags)
                     .toString();
         }

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -9,7 +9,7 @@ public class ExitCommand extends Command {
 
     public static final String COMMAND_WORD = "exit";
 
-    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting Address Book as requested ...";
+    public static final String MESSAGE_EXIT_ACKNOWLEDGEMENT = "Exiting MedDict as requested ...";
 
     @Override
     public CommandResult execute(Model model) {

--- a/src/main/java/seedu/address/logic/commands/GetIdCommand.java
+++ b/src/main/java/seedu/address/logic/commands/GetIdCommand.java
@@ -30,6 +30,10 @@ public class GetIdCommand extends Command {
         if (model.getFilteredPersonList().isEmpty()) {
             return new CommandResult(Messages.MESSAGE_INVALID_NAME);
         }
+        if (model.getFilteredPersonList().size() > 1) {
+            return new CommandResult(String.format(Messages.MESSAGE_MULTIPLE_PERSONS_WITH_THE_SAME_NAME,
+                    model.getFilteredPersonList().size()));
+        }
 
         return new CommandResult(String.format(Messages.MESSAGE_GET_ID,
                 model.getFilteredPersonList().get(0).getId()));

--- a/src/main/java/seedu/address/logic/parser/AddRemarksCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddRemarksCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ID;
@@ -10,6 +11,7 @@ import java.util.stream.Stream;
 import seedu.address.commons.exceptions.InvalidIdException;
 import seedu.address.logic.commands.AddRemarksCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Remark;
 
 
 /**
@@ -29,17 +31,19 @@ public class AddRemarksCommandParser implements Parser<AddRemarksCommand> {
                 || !argMultimap.getPreamble().isEmpty()) {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddRemarksCommand.MESSAGE_USAGE));
         }
-
-        int patientId;
-
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ID, PREFIX_REMARK);
+        String remarkInput = argMultimap.getAllValues(PREFIX_REMARK).get(0);
+        if (remarkInput.trim().isEmpty()) {
+            throw new ParseException(MESSAGE_EMPTY_REMARK);
+        }
+        int patientId;
         try {
             patientId = ParserUtil.parsePersonId(argMultimap.getAllValues(PREFIX_ID).get(0));
         } catch (InvalidIdException e) {
             throw new ParseException(MESSAGE_INVALID_ID, e);
         }
 
-        String remark = argMultimap.getValue(PREFIX_REMARK).orElse("");
+        Remark remark = new Remark(argMultimap.getValue(PREFIX_REMARK).orElse(""));
 
         return new AddRemarksCommand(patientId, remark);
     }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -68,6 +68,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns the role of a person (patient or doctor)
+     */
+    public String getPersonRole(Person person) {
+        requireNonNull(person);
+        return persons.getPersonRole(person);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -58,6 +58,11 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns the role of a person (patient or doctor)
+     */
+    String getPersonRole(Person person);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -36,10 +36,10 @@ public class ModelManager implements Model {
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
         /*
         for (Person person : filteredPersons) {
-            if (person.getRole().equals("doctor")) {
+            if (person.getRole().equals("PATIENT")) {
                 Doctor.addDoctors((Doctor) person);
             }
-            if (person.getRole().equals("patient")) {
+            if (person.getRole().equals("PATIENT")) {
                 Patient.addPatient(person);
             }
         }
@@ -101,6 +101,12 @@ public class ModelManager implements Model {
     public boolean hasPerson(Person person) {
         requireNonNull(person);
         return addressBook.hasPerson(person);
+    }
+
+    @Override
+    public String getPersonRole(Person person) {
+        requireNonNull(person);
+        return addressBook.getPersonRole(person);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -163,8 +163,15 @@ public class Person implements Appointmentable {
         }
 
         return otherPerson != null
-                && otherPerson.getName().equals(getName())
+                && normalizeName(otherPerson.getName()).equals(normalizeName(getName()))
                 && (otherPerson.getPhone().equals(getPhone()) || otherPerson.getEmail().equals(getEmail()));
+    }
+
+    /**
+     * Normalizes a name by converting it to lowercase and removing all spaces.
+     */
+    private String normalizeName(Name name) {
+        return name.toString().toLowerCase().replaceAll("\\s+", "");
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -107,8 +107,12 @@ public class Person implements Appointmentable {
         return remark;
     }
 
-    public void addNotes(String notes) {
-        this.remark.addNotes(notes);
+    /**
+     * Adds additional remarks to a person
+     */
+    public Remark addRemarks(String remarks) {
+        remark.addRemarks(remarks);
+        return remark;
     }
 
     public int getId() {

--- a/src/main/java/seedu/address/model/person/Remark.java
+++ b/src/main/java/seedu/address/model/person/Remark.java
@@ -25,7 +25,7 @@ public class Remark {
      * Adds notes to this Remark
      * @param notes notes to be added
      */
-    public void addNotes(String notes) {
+    public void addRemarks(String notes) {
         requireNonNull(notes);
         this.value += "\n" + notes;
     }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -37,6 +37,15 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns the role of a person (patient or doctor or null if undefined)
+     */
+    public String getPersonRole(Person person) {
+        requireNonNull(person);
+        return internalList.stream().filter(person::isSamePerson)
+                .map(Person::getRole).findFirst().orElse(null);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -22,7 +22,7 @@ public class SampleDataUtil {
     public static final Remark EMPTY_REMARK = new Remark("");
     private static Person person1 = new Person(
             new Name("Alex Yeoh"),
-            "patient",
+            "PATIENT",
             new Phone("87438807"),
             new Email("alexyeoh@example.com"),
             new Address("Blk 30 Geylang Street 29, #06-40"),
@@ -32,7 +32,7 @@ public class SampleDataUtil {
 
     private static Person person2 = new Person(
             new Name("Bernice Yu"),
-            "patient",
+            "PATIENT",
             new Phone("99272758"),
             new Email("berniceyu@example.com"),
             new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
@@ -42,7 +42,7 @@ public class SampleDataUtil {
 
     private static Person person3 = new Person(
             new Name("Charlotte Oliveiro"),
-            "patient",
+            "PATIENT",
             new Phone("93210283"),
             new Email("charlotte@example.com"),
             new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
@@ -52,7 +52,7 @@ public class SampleDataUtil {
 
     private static Person person4 = new Person(
             new Name("David Li"),
-            "patient",
+            "PATIENT",
             new Phone("91031282"),
             new Email("lidavid@example.com"),
             new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
@@ -62,7 +62,7 @@ public class SampleDataUtil {
 
     private static Person person5 = new Person(
             new Name("Irfan Ibrahim"),
-            "patient",
+            "PATIENT",
             new Phone("92492021"),
             new Email("irfan@example.com"),
             new Address("Blk 47 Tampines Street 20, #17-35"),
@@ -72,7 +72,7 @@ public class SampleDataUtil {
 
     private static Person person6 = new Person(
             new Name("Roy Balakrishnan"),
-            "patient",
+            "PATIENT",
             new Phone("92624417"),
             new Email("royb@example.com"),
             new Address("Blk 45 Aljunied Street 85, #11-31"),

--- a/src/test/java/seedu/address/logic/commands/AddAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddAppointmentCommandTest.java
@@ -100,6 +100,10 @@ public class AddAppointmentCommandTest {
         public void addPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/logic/commands/AddRemarksCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRemarksCommandTest.java
@@ -13,7 +13,7 @@ import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
 
-public class AddNotesCommandTest {
+public class AddRemarksCommandTest {
 
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
@@ -23,24 +23,24 @@ public class AddNotesCommandTest {
         int validPatientId = patientToEdit.getId();
         String newNotes = "New notes added.";
 
-        AddRemarksCommand addNotesCommand = new AddRemarksCommand(validPatientId, newNotes);
+        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(validPatientId, newNotes);
 
         String expectedMessage = String.format(AddRemarksCommand.MESSAGE_ADD_REMARKS_SUCCESS, newNotes, validPatientId);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         Person expectedPatient = expectedModel.getFilteredPersonList().get(0);
-        expectedPatient.addNotes(newNotes);
+        expectedPatient.addRemarks(newNotes);
 
-        assertCommandSuccess(addNotesCommand, model, expectedMessage, expectedModel);
+        assertCommandSuccess(addRemarksCommand, model, expectedMessage, expectedModel);
     }
 
     @Test
     public void execute_invalidPatientId_throwsCommandException() {
         int invalidPatientId = 9999;
-        AddRemarksCommand addNotesCommand = new AddRemarksCommand(invalidPatientId, "Some notes");
+        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(invalidPatientId, "Some notes");
         String expectedMessage = "Unable to add remarks! Check the id entered!";
 
-        assertCommandFailure(addNotesCommand, model, expectedMessage);
+        assertCommandFailure(addRemarksCommand, model, expectedMessage);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/AddRemarksCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddRemarksCommandTest.java
@@ -12,6 +12,7 @@ import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Remark;
 
 public class AddRemarksCommandTest {
 
@@ -22,10 +23,12 @@ public class AddRemarksCommandTest {
         Person patientToEdit = model.getFilteredPersonList().get(0);
         int validPatientId = patientToEdit.getId();
         String newNotes = "New notes added.";
+        Remark newRemarks = new Remark(newNotes);
 
-        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(validPatientId, newNotes);
+        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(validPatientId, newRemarks);
 
-        String expectedMessage = String.format(AddRemarksCommand.MESSAGE_ADD_REMARKS_SUCCESS, newNotes, validPatientId);
+        String expectedMessage = String.format(AddRemarksCommand.MESSAGE_ADD_REMARKS_SUCCESS,
+                newRemarks, validPatientId);
         Model expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
 
         Person expectedPatient = expectedModel.getFilteredPersonList().get(0);
@@ -37,7 +40,7 @@ public class AddRemarksCommandTest {
     @Test
     public void execute_invalidPatientId_throwsCommandException() {
         int invalidPatientId = 9999;
-        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(invalidPatientId, "Some notes");
+        AddRemarksCommand addRemarksCommand = new AddRemarksCommand(invalidPatientId, new Remark("Some notes"));
         String expectedMessage = "Unable to add remarks! Check the id entered!";
 
         assertCommandFailure(addRemarksCommand, model, expectedMessage);

--- a/src/test/java/seedu/address/logic/commands/CheckAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CheckAppointmentCommandTest.java
@@ -139,6 +139,10 @@ public class CheckAppointmentCommandTest {
         public void addPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateDoctorCommandTest.java
@@ -85,6 +85,10 @@ public class CreateDoctorCommandTest {
         public void addPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            return "DOCTOR";
+        }
 
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/logic/commands/CreatePatientCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreatePatientCommandTest.java
@@ -85,6 +85,10 @@ public class CreatePatientCommandTest {
         public void addPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            return "PATIENT";
+        }
 
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditPersonDescriptorTest.java
@@ -64,6 +64,7 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getName().orElse(null) + ", phone="
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
+                + editPersonDescriptor.getRemarks().orElse(null) + ", remarks="
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
                 + editPersonDescriptor.getTags().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());

--- a/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MarkAppointmentCommandTest.java
@@ -126,6 +126,10 @@ public class MarkAppointmentCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void deletePerson(Person target) {

--- a/src/test/java/seedu/address/logic/commands/ViewHistoryCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewHistoryCommandTest.java
@@ -122,6 +122,10 @@ public class ViewHistoryCommandTest {
         public void addPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+        @Override
+        public String getPersonRole(Person person) {
+            throw new AssertionError("This method should not be called.");
+        }
 
         @Override
         public void setAddressBook(ReadOnlyAddressBook newData) {

--- a/src/test/java/seedu/address/logic/parser/AddRemarksCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddRemarksCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.logic.Messages.MESSAGE_EMPTY_REMARK;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.Messages.MESSAGE_INVALID_ID;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_ID_AMY;
@@ -13,6 +14,7 @@ import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSucces
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.AddRemarksCommand;
+import seedu.address.model.person.Remark;
 
 public class AddRemarksCommandParserTest {
 
@@ -21,7 +23,7 @@ public class AddRemarksCommandParserTest {
     @Test
     public void parse_validArgs_returnsAddNotesCommand() {
         String userInput = " " + PREFIX_ID + VALID_ID_AMY + " " + PREFIX_REMARK + VALID_REMARK_AMY;
-        AddRemarksCommand expectedCommand = new AddRemarksCommand(VALID_ID_AMY, VALID_REMARK_AMY);
+        AddRemarksCommand expectedCommand = new AddRemarksCommand(VALID_ID_AMY, new Remark(VALID_REMARK_AMY));
         assertParseSuccess(parser, userInput, expectedCommand);
     }
 
@@ -29,6 +31,12 @@ public class AddRemarksCommandParserTest {
     public void parse_invalidId_throwsParseException() {
         String userInput = " " + PREFIX_ID + "abc" + " " + PREFIX_REMARK + VALID_REMARK_AMY;
         assertParseFailure(parser, userInput, MESSAGE_INVALID_ID);
+    }
+
+    @Test
+    public void parse_emptyRemarks_throwsParseException() {
+        String userInput = " " + PREFIX_ID + "abc" + " " + PREFIX_REMARK + " ";
+        assertParseFailure(parser, userInput, MESSAGE_EMPTY_REMARK);
     }
 
     @Test

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -19,8 +19,8 @@
 //
 //public class JsonAdaptedPersonTest {
 //    private static final String INVALID_NAME = "R@chel";
-//    private static final String PATIENT_ROLE = "patient";
-//    private static final String DOCTOR_ROLE = "doctor";
+//    private static final String PATIENT_ROLE = "PATIENT";
+//    private static final String DOCTOR_ROLE = "DOCTOR";
 //    private static final String INVALID_PHONE = "+651234";
 //    private static final String INVALID_ADDRESS = " ";
 //    private static final String INVALID_EMAIL = "example.com";

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -19,8 +19,8 @@ public class PersonBuilder {
 
     public static final String DEFAULT_NAME = "Amy Beeee";
     public static final int DEFAULT_ID = 12;
-    public static final String DEFAULT_PATIENT_ROLE = "patient";
-    public static final String DEFAULT_DOCTOR_ROLE = "doctor";
+    public static final String DEFAULT_PATIENT_ROLE = "PATIENT";
+    public static final String DEFAULT_DOCTOR_ROLE = "DOCTOR";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";


### PR DESCRIPTION
The new changes are:
1. the edit command can now edit the remarks of a person
2. when addR command is called, the results will be reflected instantly. The addR command will only work on patients
3. The CreateP and CreateD commands are now case-insensitive and able to ignore white lines to check whether two names are the same. They are able to differentiate duplicate persons of the same role or different roles and render different error messages.
4. The getId now will render dynamic messages if there are more than one person that suits the name keywords.

Closes #161 
Closes #154 
Closes #156 
Closes #157 
Closes #150 